### PR TITLE
using biplist to write binary plist before PlistInfo.to_binary can be…

### DIFF
--- a/gplist/plist.py
+++ b/gplist/plist.py
@@ -429,6 +429,9 @@ class PlistInfo(OrderedDict):
         return obj_count
 
     def to_binary(self):
+        import biplist
+        return biplist.writePlistToString(self)
+
         self.obj_index = 0
         self.obj_offsets = {}
         self._values = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+biplist
 cryptography

--- a/tests/test_plist.py
+++ b/tests/test_plist.py
@@ -2,11 +2,11 @@
 """test plist info
 """
 
+from gplist.plist import PlistInfo, DictPlistInfo
 import os
 import unittest
 
 import biplist
-from gplist.plist import PlistInfo, DictPlistInfo
 
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
… recognized by macOS